### PR TITLE
InfoBot: Minimum user permission for lock/unlock now configurable

### DIFF
--- a/config/default_config.js
+++ b/config/default_config.js
@@ -80,6 +80,8 @@ exports.default = {
 		info_bot 			: false,
 		//an array of words for info_bot to ignore.
 		info_bot_ignore 	: ["who", "what", "wat", "wot", "where", "why", "y", "he", "she", "they", "it", "us", "me", "you", "I", "but", "up"],
+		// minimum user permission at which "lock" and "unlock" will work (defaults to "~", but some IRC servers like ircd-hybrid don't have that by default, and you may want it to be lower anyway)
+		info_bot_minimum_lock_perm	: '~',
 
 		//auto kick/ban users who are inactive for a long enough period of time
 		autokb_users_inactive_for: 0, //2629746000 = 1mo, setting a time in ms > 0 enables this setting

--- a/lib/chan.js
+++ b/lib/chan.js
@@ -295,7 +295,12 @@ module.exports = class CHAN {
 
 			//if this is enabled it does a basic replication of an infobot
 			if(_this.config.info_bot){
-				_this.infobot.check_message(_this, text, (_this.users[nick] && _this.users[nick].perm === '~' ? true : false), nick);
+				// "~" was hardcoded, but some IRC servers (ircd-hybrid, for instance) don't have that by default, so we now check the config
+				var has_lock_perm = false;
+				if(_this.config.info_bot_minimum_lock_perm && config.permissions.indexOf(_this.users[nick].perm) >= config.permissions.indexOf(_this.config.info_bot_minimum_lock_perm)) {
+					var has_lock_perm = true;
+				}
+				_this.infobot.check_message(_this, text, (_this.users[nick] && has_lock_perm ? true : false), nick);
 			}
 		}
 	}


### PR DESCRIPTION
While working through some issues to get b0t functional on ircd-hybrid (which looks promising, by the way!), I discovered a hardcoded permissions check in InfoBot. This will make that configurable, especially for IRC servers like Hybrid that don't have the tilde by default. The new configuration option, "info_bot_minimum_lock_perm", still defaults to the tilde, but it can be set to whatever permissions level the user wants. Any user at or above that permission level will be able to lock and unlock InfoBot factoids.