### PR TITLE
OperServ admin command support

### DIFF
--- a/config/default_config.js
+++ b/config/default_config.js
@@ -28,6 +28,12 @@ exports.default = {
 	nickserv_password			: "", //NickServ registration password. You don't have to have this, but if your b0t isn't registered it may cause problems with commands.
 	ircop_password				: "", //If your b0t is an ircop on your network, set their oper password here.
 
+	// some IRC servers (ircd-hybrid, for example) do not have SA* commands (i.e. SAMODE, SAJOIN, etc.), so if this applies to you, you can set this to "true" to use OperServ commands instead (which obviously requires IRC services provided by i.e. Anope, as well as the bot being listed as an OPER in the services configuration)
+	use_serv_for_admin_commands	: false,
+
+	// also, some IRC servers (again, using ircd-hybrid for an example) don't support "+a", so here you can make the bot use another op-like mode ("+o, for instance")
+	bot_op_mode	: "a",
+
 	//These are all the settings that are used to connect the b0t to the server
 	//http://node-irc.readthedocs.io/en/latest/API.html
 	bot_config: {

--- a/config/default_config.js
+++ b/config/default_config.js
@@ -80,6 +80,8 @@ exports.default = {
 		info_bot 			: false,
 		//an array of words for info_bot to ignore.
 		info_bot_ignore 	: ["who", "what", "wat", "wot", "where", "why", "y", "he", "she", "they", "it", "us", "me", "you", "I", "but", "up"],
+		// minimum user permission at which "lock" and "unlock" will work (defaults to "~", but some IRC servers like ircd-hybrid don't have that by default, and you may want it to be lower anyway)
+		info_bot_minimum_lock_perm	: '~',
 
 		//auto kick/ban users who are inactive for a long enough period of time
 		autokb_users_inactive_for: 0, //2629746000 = 1mo, setting a time in ms > 0 enables this setting

--- a/lib/chan.js
+++ b/lib/chan.js
@@ -295,7 +295,12 @@ module.exports = class CHAN {
 
 			//if this is enabled it does a basic replication of an infobot
 			if(_this.config.info_bot){
-				_this.infobot.check_message(_this, text, (_this.users[nick] && _this.users[nick].perm === '~' ? true : false), nick);
+				// "~" was hardcoded, but some IRC servers (ircd-hybrid, for instance) don't have that by default, so we now check the config
+				var has_lock_perm = false;
+				if(_this.config.info_bot_minimum_lock_perm && config.permissions.indexOf(_this.users[nick].perm) >= config.permissions.indexOf(_this.config.info_bot_minimum_lock_perm)) {
+					var has_lock_perm = true;
+				}
+				_this.infobot.check_message(_this, text, (_this.users[nick] && has_lock_perm ? true : false), nick);
 			}
 		}
 	}

--- a/lib/chan.js
+++ b/lib/chan.js
@@ -52,7 +52,15 @@ module.exports = class CHAN {
 		}*/
 
 		if(b.is_op){
-			bot.send('samode', _this.chan, '+a', bot.nick);
+			// look at the config to see if SAMODE can be used, or if OperServ is the way to go
+			if(config.use_serv_for_admin_commands && config.use_serv_for_admin_commands == true) {
+				_this.log.info('Trying to use OperServ to gain ops');
+				bot.say('OperServ', 'MODE ' + _this.chan + ' ' + (config.bot_op_mode ? '+' + config.bot_op_mode : '+a') + ' ' + bot.nick);
+			}
+			else {
+				_this.log.info('Trying to use SAMODE to gain ops');
+				bot.send('samode', _this.chan, config.bot_op_mode ? '+' + config.bot_op_mode : '+a', bot.nick);
+			}
 		}
 
 		//check if there are any open polls for the channel

--- a/lib/user.js
+++ b/lib/user.js
@@ -28,7 +28,7 @@ module.exports = class USER{
 			return b.channels[this.chan];
 		} else {
 			return b.pm;
-		} 
+		}
 	}
 
 	get log(){
@@ -61,7 +61,7 @@ module.exports = class USER{
 		return false;
 	}
 
-	get nick_org(){ 
+	get nick_org(){
 		for(var who in b.users.on_server){
 			if(b.users.on_server[who].nick === this.nick){
 				return b.users.on_server[who].nick_org;
@@ -71,7 +71,7 @@ module.exports = class USER{
 		return null;
 	}
 
-	get who(){ 
+	get who(){
 		for(var who in b.users.on_server){
 			if(b.users.on_server[who].nick === this.nick){
 				return who;
@@ -81,7 +81,7 @@ module.exports = class USER{
 		return null;
 	}
 
-	get who_org(){ 
+	get who_org(){
 		for(var who in b.users.on_server){
 			if(b.users.on_server[who].nick === this.nick){
 				return b.users.on_server[who].who_org;
@@ -91,7 +91,7 @@ module.exports = class USER{
 		return null;
 	}
 
-	get registered(){ 
+	get registered(){
 		for(var who in b.users.on_server){
 			if(b.users.on_server[who].nick === this.nick){
 				return b.users.on_server[who].registered;
@@ -112,7 +112,7 @@ module.exports = class USER{
 			callback();
 		}
 	}
-	
+
 	//chan only
 	set_user_modes(){
 		var _this = this;
@@ -133,13 +133,19 @@ module.exports = class USER{
 
 					if(b.is_op){
 						if(_this.config.make_owner_chan_owner && _this.perm !== '~'){
-							bot.send('samode', _this.chan, '+q', _this.nick);
+							// use OperServ if the config says so
+							if(config.use_serv_for_admin_commands && config.use_serv_for_admin_commands == true) {
+								bot.say('OperServ', 'MODE ' + _this.chan + ' +q ' + bot.nick);
+							}
+							else {
+								bot.send('samode', _this.chan, '+q', _this.nick);
+							}
 							_this.log.info(_this.who, 'chan owner +q');
 							_this.perm = '~';
-						} 
+						}
 					} else {
-						_this.log.trace(bot.nick, 'is not opper, cannot samode +q');
-					} 
+						_this.log.trace(bot.nick, 'is not opper, cannot set mode to +q');
+					}
 				} else {
 					if(b.is_op && _this.perm === '' && _this.config.voice_users_on_join){
 						bot.send('mode', _this.chan, '+v', _this.nick);

--- a/lib/users.js
+++ b/lib/users.js
@@ -91,7 +91,7 @@ module.exports = class USERS{
 		}
 	}
 
-	//from NOTICE, create new entry in the notice queue to be parsed, in time order. 
+	//from NOTICE, create new entry in the notice queue to be parsed, in time order.
 	//If time already exists, add notice to that array (to group notice lines together)
 	new_info_notice(notice){
 		var _this = this;
@@ -174,7 +174,13 @@ module.exports = class USERS{
 	nick_change(nick, new_nick, callback){
 		if(b.is_op){
 			this.nick_change_queue[nick] = {new_nick: new_nick, callback: callback ? callback : function(){}};
-			bot.send('sanick', nick, new_nick);
+			// check for OperServ usage
+			if(config.use_serv_for_admin_commands && config.use_serv_for_admin_commands == true) {
+				bot.say('OperServ', 'SVSNICK ' + nick + ' ' + new_nick);
+			}
+			else {
+				bot.send('sanick', nick, new_nick);
+			}
 		} else {
 			b.log.error('nick_change', bot.nick, 'is not opper')
 			callback();
@@ -298,7 +304,7 @@ module.exports = class USERS{
 								if(b.channels[chan] && !b.channels[chan].users[_this.on_server[usr_who].nick]){
 									//b.log.debug('1 new user', _this.on_server[usr_who].nick, usr_who, chan, _this.on_server[usr_who].chans[chan]);
 
-									b.channels[chan].users[_this.on_server[usr_who].nick] = 
+									b.channels[chan].users[_this.on_server[usr_who].nick] =
 										new User(_this.on_server[usr_who].nick, chan, _this.on_server[usr_who].chans[chan], (join && join === chan));
 								} else if(b.channels[chan] && b.channels[chan].users[_this.on_server[usr_who].nick]) {
 									//update permissions
@@ -329,7 +335,7 @@ module.exports = class USERS{
 							if(user_data.who.match(match_owner_regex) !== null){
 								user_data.is_owner = true;
 								b.log.info(user_data.who, 'made b0t owner', match_owner_regex);
-							} 
+							}
 
 							_this.on_server[usr.who[0]] = user_data;
 
@@ -339,7 +345,7 @@ module.exports = class USERS{
 									if(b.channels[chan] && !b.channels[chan].users[user_data.nick]){
 										//b.log.debug('2 new user', user_data.nick, usr.who[0], chan, user_data.chans[chan]);
 
-										b.channels[chan].users[user_data.nick] = 
+										b.channels[chan].users[user_data.nick] =
 											new User(user_data.nick, chan, user_data.chans[chan], (join && join === chan));
 									}
 								}
@@ -351,7 +357,7 @@ module.exports = class USERS{
 								user_data.callback(callback_data);
 								delete user_data.callback;
 							}
-							
+
 						} else {
 							if(!_this.who_queue[user_data.nick]){
 								_this.who_queue[user_data.nick] = user_data;
@@ -428,7 +434,7 @@ module.exports = class USERS{
 				user: '*',
 				host: '*'
 			}
-		} 
+		}
 
 		callback(return_regex ? create_regex(user_data) : user_data);
 	};
@@ -456,7 +462,7 @@ module.exports = class USERS{
 			}
 		} else {
 			return callback(owner_nicks);
-		} 
+		}
 	};
 
 	//USER can be a USER obj or a nickname
@@ -657,12 +663,12 @@ module.exports = class USERS{
 			spoke.letters = data.spoke && data.spoke.letters !== undefined ? +data.spoke.letters + text.length : text.length;
 			spoke.words = data.spoke && data.spoke.words !== undefined ? +data.spoke.words + words.length : words.length;
 			spoke.lines = data.spoke && data.spoke.lines !== undefined ? +data.spoke.lines + 1 : 1;
-			
+
 			db.update("/nicks/" + data.nick_org + '/spoke', spoke, true, undefined, data.nick_org);
 		});
 	}
 
-	update_last_seen(nick, chan, action, where, text){ 
+	update_last_seen(nick, chan, action, where, text){
 		var _this = this;
 		var seen_data = {
 			date: (new dateWithOffset(0)).getTime(),
@@ -704,13 +710,13 @@ module.exports = class USERS{
 					var last_spoke = data.spoke && data.spoke.text && data.spoke.text.length > 0 && data.spoke.text[0].date ? data.spoke.text[0].date : false;
 
 					b.log.debug('autokb', nick, 'last_seen', last_seen, 'last_spoke', last_spoke);
-					
+
 					if(!last_seen && !last_spoke){
 						b.log.warn('autokb', nick, 'has never been seen and never spoke');
 					} else if(!last_seen && last_spoke){
 						b.log.warn('autokb', nick, 'has never been seen, but has spoke (this really should not happen)');
 					} else if(last_seen && !last_spoke){
-				  
+
 						//this is where our threshold comes into effect, as technically this should only apply to new users
 						if(now - chan_config.autokb_new_user_threshold > last_seen)
 						{
@@ -741,7 +747,7 @@ module.exports = class USERS{
 							var kb_data = { auto_kb: {} };
 							kb_data.auto_kb[chan] = now;
 							_this.update_user(nick, kb_data, function(){});
-							
+
 						}
 					}
 				});
@@ -770,7 +776,7 @@ module.exports = class USERS{
 			register_syntax: null, //by default, tries to get syntax for col as command. if col is not a command and skip_say:true, this should not be null
 			skip_say: false, //return false instead of error message if not registered
 			ignore_err: false,
-			return_all: false, //if true, return an object of all the user data (if col is set, throws error if col doesn't exist in user data) 
+			return_all: false, //if true, return an object of all the user data (if col is set, throws error if col doesn't exist in user data)
 			use_nick_org: true, //if false, doesn't look to see if the user has an original nick
 			return_nicks: false //if true, adds nick and nick org to output arr
 		}, options);
@@ -784,7 +790,7 @@ module.exports = class USERS{
 
 			if(options.label === null && cmd_data.params && cmd_data.params[0] && cmd_data.params[0].or && cmd_data.params[0].or[0] && cmd_data.params[0].or[0].key){
 				options.label = cmd_data.params[0].or[0].key;
-			} 
+			}
 
 			if(options.label === null && options.col !== '') options.label = options.col;
 
@@ -831,7 +837,7 @@ module.exports = class USERS{
 				get_usr_data("/nicks/" + nick + '/' + (options.return_all ? '' : options.col));
 			}
 		}
-		
+
 		function get_usr_data(path){
 			db.get_data(path, function(user_data){
 				if(options.return_all === false && user_data !== null && user_data !== ''){
@@ -841,7 +847,7 @@ module.exports = class USERS{
 					}
 					callback(user_data);
 					return;
-				} else if (options.return_all === true && user_data !== null && user_data !== '' && 
+				} else if (options.return_all === true && user_data !== null && user_data !== '' &&
 							user_data[options.col] !== undefined && user_data[options.col] !== '' && user_data[options.col] !== null){
 					callback(user_data[options.col], user_data);
 					return;

--- a/plugins/default/cmds.js
+++ b/plugins/default/cmds.js
@@ -1001,7 +1001,14 @@ var cmds = {
 							var chans = Object.keys(d.auto_kb);
 							for(var chan in d.auto_kb){
 								bot.send('mode', chan, '-b', USER.nick + '!*@*');
-								bot.send('sajoin', USER.nick, chan);
+
+								// check for OperServ
+								if(config.use_serv_for_admin_commands && config.use_serv_for_admin_commands == true) {
+									bot.say('OperServ', 'svsjoin ', USER.nick, chan);
+								}
+								else {
+									bot.send('sajoin', USER.nick, chan);
+								}
 							}
 							db.delete("/nicks/" + USER.nick + '/auto_kb', function(){
 								say({succ: 'You have been unbanned from: ' + chans.join(', ') + ' you can now rejoin if you were not autojoined.' });

--- a/plugins/random/cmds.js
+++ b/plugins/random/cmds.js
@@ -573,16 +573,31 @@ var cmds = {
 							if(force_fire_on) {
 								say(CHAN.t.success('Click! ' + hit_nick + ' gets a new nickname!'), 1, {skip_verify: true});
 								var new_nick = x.rand_arr(russian_nick);
-								if(!debug) bot.send('sanick', hit_nick, new_nick);
-								if(debug) CHAN.log.debug('sanick', hit_nick, new_nick);
+								// need to check for OperServ
+								if(config.use_serv_for_admin_commands && config.use_serv_for_admin_commands == true) {
+									bot.say('OperServ', 'svsnick ' + hit_nick + ' ' + new_nick);
+									if(debug) CHAN.log.debug('msg OperServ svsnick', hit_nick, new_nick);
+								}
+								else {
+									bot.send('sanick', hit_nick, new_nick);
+									if(debug) CHAN.log.debug('sanick', hit_nick, new_nick);
+								}
+
 								if(!debug) hit_nick = new_nick;
 							} else if(misfire){
 								say(CHAN.t.success('Click! Watch where you\'re pointing that thing! ' + hit_nick + ', enjoy your new nickname!'), 1, {skip_verify: true});
 							} else {
 								say(CHAN.t.success('Click! Enjoy your new nickname!'), 1, {skip_verify: true});
 							}
-							if(!debug) bot.send('sanick', hit_nick, x.rand_arr(russian_nick));
-							if(debug) CHAN.log.debug('sanick', hit_nick, x.rand_arr(russian_nick));
+							// check for OperServ here, too
+							if(config.use_serv_for_admin_commands && config.use_serv_for_admin_commands == true) {
+								bot.say('OperServ', 'svsnick ' + hit_nick + ' ' + x.rand_arr(russian_nick));
+								if(debug) CHAN.log.debug('msg OperServ svsnick', hit_nick, x.rand_arr(russian_nick));
+							}
+							else {
+								bot.send('sanick', hit_nick, x.rand_arr(russian_nick));
+								if(debug) CHAN.log.debug('sanick', hit_nick, x.rand_arr(russian_nick));
+							}
 							break;
 						case 4:
 							if(['~', '&', '@'].includes(CHAN.users[hit_nick].perm))


### PR DESCRIPTION
There were a few places in b0t where the code had assumptions that commands like SAMODE and SANICK exist. That is not the case for ircd-hybrid; instead, it relies on OperServ to carry out these functions.

I added a couple of configuration items to determine which route to take, since at the point in libs/chan.js where b0t takes channel ops, it's a royal pain to check whether the server actually supports certain commands. If the configuration says to use OperServ, it will use OperServ's MODE command instead of SAMODE, OperServ's SVSNICK instead of SANICK, and OperServ's SVSJOIN instead of SAJOIN. I didn't find any other instances of these commands being used.

OperServ functionality requires b0t to have IRC OPER permission, as well as being registered with NickServ and configured as a services administrator in OperServ (or at least a user that can execute the OperServ MODE, SVSNICK, and SVSJOIN commands). The b0t default is not to use OperServ.

I also added another configuration option for setting which permission that b0t actually uses when it sets its own channel permission. As you may guess, "a" doesn't exist in default ircd-hybrid, so now the user can configure whether they want to use "o" or whatever else. The b0t default is "a".