### PR TITLE
Ping/Pong: Sending a "!ping" PM to b0t caused an unhandled exception

### DIFF
--- a/b0t.js
+++ b/b0t.js
@@ -238,7 +238,10 @@ function init_bot(){
 				break;
 			case 'PONG':
 				for(var i = b.waiting_for_pong.length; i--;){
-					bot.say(b.waiting_for_pong[i], 'pong');
+					// this could be undefined if "!ping" is sent in a bot PM, which would cause the "say" line to crash
+					if(typeof b.waiting_for_pong[i] != 'undefined') {
+						bot.say(b.waiting_for_pong[i], 'pong');
+					}
 					b.waiting_for_pong.splice(i, 1)
 				}
 				x.pong();


### PR DESCRIPTION
Here's yet another one. If you send "!ping" to b0t in a PM, it results in the "channel" being undefined, which means that it crashes the bot. This fix checks to make sure that each channel in the list of channels waiting for a "pong" is defined. A better way would probably be to figure out how to handle a ping request that comes over in a PM, but I've made enough of these PRs recently :)